### PR TITLE
각방제어보일러를 위한 slave_id 및 api 처리 수정

### DIFF
--- a/custom_components/kiturami/api.py
+++ b/custom_components/kiturami/api.py
@@ -55,8 +55,8 @@ class KrbClient:
         self.auth_key = result['authKey']
         return self.auth_key
 
-    async def async_get_device_list(self) -> List[Dict]:
-        """장치 목록을 가져옵니다."""
+    async def async_get_normal_device_list(self) -> List[Dict]:
+        """단일보일러 장치 목록을 가져옵니다."""
         url = f'{KITURAMI_API_URL}/member/getMemberNormalDeviceList'
         args = {
             'parentId': '1'
@@ -64,6 +64,24 @@ class KrbClient:
         response = await self.async_post(url, args)
         return response['memberDeviceList']
 
+    async def async_get_device_list(self) -> List[Dict]:
+        """각방보일러 장치 목록을 가져옵니다."""
+        url = f'{KITURAMI_API_URL}/member/getMemberDeviceList'
+        args = {
+            'parentId': '1'
+        }
+        response = await self.async_post(url, args)
+        return response['memberDeviceList']
+
+    async def async_get_device_info(self, node_id: str) -> List[Dict]:
+        """각방보일러 각방장치 정보를 가져옵니다."""
+        url = f'{KITURAMI_API_URL}/device/getDeviceInfo'
+        args = {
+            'nodeId': node_id,
+            'parentId': '1'
+        }
+        response = await self.async_post(url, args)
+        return response['deviceSlaveInfo']
 
 class KrbAPI:
     """귀뚜라미 API"""
@@ -80,71 +98,62 @@ class KrbAPI:
         }
         return await self.client.async_post(url, args)
 
-    async def async_get_device_info(self, node_id: str):
-        """장치 정보를 가져옵니다."""
-        url = f'{KITURAMI_API_URL}/device/getDeviceInfo'
-        args = {
-            'nodeId': node_id,
-            'parentId': '1'
-        }
-        return await self.client.async_post(url, args)
-
-    async def async_device_mode_info(self, parent_id: str, node_id: str, action_id='0102'):
+    async def async_device_mode_info(self, parent_id: str, node_id: str, slave_id: str, action_id='0102'):
         """장치 모드 정보를 가져옵니다."""
         url = f'{KITURAMI_API_URL}/device/getDeviceModeInfo'
         args = {
             'nodeId': node_id,
             'actionId': action_id,
             'parentId': parent_id,
-            'slaveId': '01'
+            'slaveId': slave_id
         }
         return await self.client.async_post(url, args)
 
-    async def async_device_control(self, node_id: str, message_id, message_body):
+    async def async_device_control(self, node_id: str, slave_id: str, message_id, message_body):
         """장치를 제어합니다."""
         url = f'{KITURAMI_API_URL}/device/deviceControl'
         args = {
             'nodeIds': [node_id],
             'messageId': message_id,
-            'messageBody': message_body
+            'messageBody': slave_id + message_body
         }
         return await self.client.async_post(url, args)
 
-    async def async_turn_on(self, node_id: str):
+    async def async_turn_on(self, node_id: str, slave_id: str):
         """장치를 켭니다."""
-        await self.async_device_control(node_id, '0101', '010000000001')
+        await self.async_device_control(node_id, slave_id, '0101', '0000000001')
 
-    async def async_turn_off(self, node_id: str):
+    async def async_turn_off(self, node_id: str, slave_id: str):
         """장치를 끕니다."""
-        await self.async_device_control(node_id, '0101', '010000000002')
+        await self.async_device_control(node_id, slave_id, '0101', '0000000002')
 
-    async def async_mode_heat(self, parent_id: str, node_id: str, target_temp: Optional[str] = None):
+    async def async_mode_heat(self, parent_id: str, node_id: str, slave_id: str, target_temp: Optional[str] = None):
         """장치를 난방 모드로 설정합니다."""
         if not target_temp:
-            response = await self.async_device_mode_info(parent_id, node_id, '0102')
+            response = await self.async_device_mode_info(parent_id, node_id, slave_id, '0102')
             target_temp = response['value']
-        body = f'01000000{target_temp}00'
-        await self.async_device_control(node_id, '0102', body)
+        body = f'000000{target_temp}00'
+        await self.async_device_control(node_id, slave_id, '0102', body)
 
     async def async_mode_bath(self, parent_id: str, node_id: str):
         """장치를 목욕 모드로 설정합니다."""
-        response = await self.async_device_mode_info(parent_id, node_id, '0105')
+        response = await self.async_device_mode_info(parent_id, node_id, slave_id, '0105')
         value = response['value']
         body = f'00000000{value}00'
-        await self.async_device_control(node_id, '0105', body)
+        await self.async_device_control(node_id, '', '0105', body)
 
-    async def async_mode_reservation(self, parent_id: str, node_id: str):
+    async def async_mode_reservation(self, parent_id: str, node_id: str, slave_id: str):
         """장치를 예약 모드로 설정합니다."""
-        response = await self.async_device_mode_info(parent_id, node_id, '0107')
-        body = f'01{response['value']}'
-        await self.async_device_control(node_id, '0107', body)
+        response = await self.async_device_mode_info(parent_id, node_id, slave_id, '0107')
+        body = f'{response['value']}'
+        await self.async_device_control(node_id, slave_id, '0107', body)
 
-    async def async_mode_reservation_repeat(self, parent_id: str, node_id: str):
+    async def async_mode_reservation_repeat(self, parent_id: str, node_id: str, slave_id: str):
         """장치를 반복 예약 모드로 설정합니다."""
-        response = await self.async_device_mode_info(parent_id, node_id, '0108')
-        body = f'01000000{response['value']}{response['option1']}'
-        await self.async_device_control(node_id, '0108', body)
+        response = await self.async_device_mode_info(parent_id, node_id, slave_id, '0108')
+        body = f'000000{response['value']}{response['option1']}'
+        await self.async_device_control(node_id, slave_id, '0108', body)
 
-    async def async_mode_away(self, node_id: str):
+    async def async_mode_away(self, node_id: str, slave_id: str):
         """장치를 외출 모드로 설정합니다."""
-        await self.async_device_control(node_id, '0106', '010200000000')
+        await self.async_device_control(node_id, slave_id, '0106', '0200000000')

--- a/custom_components/kiturami/climate.py
+++ b/custom_components/kiturami/climate.py
@@ -56,7 +56,7 @@ class KituramiClimate(ClimateEntity):
 
     def __init__(self, api: KrbAPI, parent_id: str, node_id: str, slave_id: str, name: str, is_single_type: bool, _min_time_between_updates: int):
         self._api: KrbAPI = api
-        self._min_time_between_updates: datetime.timedelta = timedelta(minutes=_min_time_between_updates)
+        self._min_time_between_updates: datetime.timedelta = timedelta(seconds=_min_time_between_updates)
         self._parent_id = parent_id
         self._node_id = node_id
         self._slave_id = slave_id

--- a/custom_components/kiturami/config_flow.py
+++ b/custom_components/kiturami/config_flow.py
@@ -16,8 +16,8 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): str,
         vol.Required(
             CONF_SCAN_INTERVAL,
-            default=15,
-        ): vol.All(vol.Coerce(int), vol.Range(min=5)),
+            default=30,
+        ): vol.All(vol.Coerce(int), vol.Range(min=30)),
     }
 )
 

--- a/custom_components/kiturami/translations/ko.json
+++ b/custom_components/kiturami/translations/ko.json
@@ -13,7 +13,7 @@
         "data": {
           "username": "아이디",
           "password": "비밀번호",
-          "scan_interval": "동기화 간격 (분)"
+          "scan_interval": "동기화 간격 (초)"
         }
       }
     }


### PR DESCRIPTION
안녕하세요,
네이버HA 카페 이머징 입니다.

kiturami 보일러 기능 덕분에 잘 쓰고 있습니다.
저희집은 각방제어 보일러라 일부 수정 하여 동작 가능 하도록 했는데요
수정된 내용은 아래와 같고 기존의 단일 보일러 기능에 영향 없는 상태에서
각방제어 보일러도 구동 가능 하도록 간단하게 수정 했습니다.

1. entity 등록시 보일러 정보 조회 부분
단일보일러용: 
  async_get_normal_device_list -> 보일러정보
각방제어보일러용: 
  async_get_device_list -> 메인컨트롤러정보
  async_get_device_info -> 각방 온도조절기 정보, 여기서 slave_id 가 조회 됨              

2. slave_id 처리 부분
Bath 를 제외한 각 API 의 payload message 가 "01" 로 시작 하는데요.
각방제어 보일러의 경우 각 방은 01, 02, 03, ... 이런식으로 구분 됩니다.
이 값이 slave_id 에 해당 됩니다.

3. entity_id, unique_id
각방제어용은 두개 id 가 각방컨트롤러별로 구분 필요하기 때문에
기존 단일 보일러에는 영향 없도록 수정 했습니다.

![image](https://github.com/user-attachments/assets/d166de6e-d78a-4caa-b451-f1199504ba1c)
